### PR TITLE
Yet2 366 product summary

### DIFF
--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -198,6 +198,8 @@ async function generateProductHtml(product, ctx, state) {
     product.dissociationconstant = parseJson(product?.raw?.adantibodydissociationconstantjson);
     product.speciesreactivity = parseJson(product?.raw?.adspeciesreactivityjson);
     product.secondaryantibodytargetisotypes = product?.raw?.adsecondaryantibodyattributestargetisotypes?.split(';')?.join(', ') || '';
+    product.productsummary = parseJson(product?.raw?.adproductsummaryjson);
+    product.generalsummary = product.productsummary?.generalSummary || product.raw.adproductsummary;
 
     // load the templates
     const templateNames = [

--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -136,6 +136,8 @@ async function generateProductHtml(product, ctx, state) {
     // const product = JSON.parse(data?.toString());
     logger.debug(product?.raw?.adproductslug || "No adproductslug found");
 
+    product.productmetatitle = product.raw.admetatitle || product.raw.adgentitle || product.title;
+    product.productmetadescription = product.raw.admetadescription || product.raw.adgenshortdescription || '';
     product.categorytype = product.raw.adcategorytype;
     product.reviewssummary = parseJson(product.raw.reviewssummaryjson);
     product.targetdata = parseJson(product.raw.targetjson);

--- a/actions/templates/us/page.html
+++ b/actions/templates/us/page.html
@@ -2,8 +2,8 @@
 
 <head>
   <meta charset="utf-8">
-  <title>{{title}}</title>
-  <meta name="description" content="{{raw.description}}">
+  <title>{{productmetatitle}}</title>
+  <meta name="description" content="{{productmetadescription}}">
   <meta name="published-time" content="where in json?">
   <meta name="modified-time" content="where in json?">
   <meta name="category-type" content="{{raw.adcategorytype}}">

--- a/actions/templates/us/product-header-block.html
+++ b/actions/templates/us/product-header-block.html
@@ -29,7 +29,7 @@
             {{else}}
                 <em>({{raw.adpublicationscount}} Publication)</em>
             {{/if}}
-            <div><p>{{{raw.adproductsummary}}}</p></div>
+            <div><p>{{{generalsummary}}}</p></div>
         </div>
         <div>
             <p>View alternative names</p>


### PR DESCRIPTION
Updated product summary logic by replacing adproductsummary (deprecated in 1.0) with adproductsummaryJSON:generalSummary